### PR TITLE
添加对m3u8dl链接协议的支持

### DIFF
--- a/N_m3u8DL-CLI/MyOptions.cs
+++ b/N_m3u8DL-CLI/MyOptions.cs
@@ -91,5 +91,11 @@ namespace N_m3u8DL_CLI
         [Option("noProxy", HelpText = "Help_noProxy", ResourceType = typeof(strings))]
         public bool NoProxy { get; set; }
 
+        [Option("registerUrlProtocol", HelpText = "Help_registerUrlProtocol", ResourceType = typeof(strings))]
+        public bool RegisterUrlProtocol { get; set; }
+
+        [Option("unregisterUrlProtocol", HelpText = "Help_unregisterUrlProtocol", ResourceType = typeof(strings))]
+        public bool UnregisterUrlProtocol { get; set; }
+
     }
 }

--- a/N_m3u8DL-CLI/N_m3u8DL-CLI.csproj
+++ b/N_m3u8DL-CLI/N_m3u8DL-CLI.csproj
@@ -54,6 +54,9 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.JScript" />
+    <Reference Include="Microsoft.Win32.TaskScheduler, Version=2.8.7.0, Culture=neutral, PublicKeyToken=c416bc1b32d97233, processorArchitecture=MSIL">
+      <HintPath>..\packages\TaskScheduler.2.8.7\lib\net452\Microsoft.Win32.TaskScheduler.dll</HintPath>
+    </Reference>
     <Reference Include="MihaZupan.HttpToSocks5Proxy, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HttpToSocks5Proxy.1.4.0\lib\net45\MihaZupan.HttpToSocks5Proxy.dll</HintPath>
     </Reference>
@@ -68,17 +71,23 @@
     <Reference Include="System" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.IO" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="UACHelper, Version=1.3.0.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UACHelper.1.3.0.5\lib\net40\UACHelper.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Decode51CtoKey.cs" />
@@ -142,14 +151,17 @@
     <EmbeddedResource Include="strings.en-US.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>strings.en-US.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="strings.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>strings.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="strings.zh-TW.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>strings.zh-TW.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/N_m3u8DL-CLI/Program.cs
+++ b/N_m3u8DL-CLI/Program.cs
@@ -10,11 +10,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.Win32;
 
 namespace N_m3u8DL_CLI.NetCore
 {
@@ -69,6 +71,31 @@ namespace N_m3u8DL_CLI.NetCore
                 Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(loc);
             }
             catch (Exception) {; }
+
+            // 处理m3u8dl URL协议
+            if (args.Length == 1)
+            {
+                if (args[0].ToLower().StartsWith("m3u8dl:"))
+                {
+                    var valueBytes = Convert.FromBase64String(args[0].Substring(7));
+                    var cmd = Encoding.UTF8.GetString(valueBytes);
+                    args = Global.ParseArguments(cmd).ToArray();  //解析命令行
+                }
+                else if (args[0] == "--registerUrlProtocol")
+                {
+                    RequireElevated(string.Join(" ", args));
+                    bool result = RegisterUriScheme("m3u8dl", Assembly.GetExecutingAssembly().Location);
+                    Console.WriteLine(result ? strings.registerUrlProtocolSuccessful : strings.registerUrlProtocolFailed);
+                    Environment.Exit(0);
+                }
+                else if (args[0] == "--unregisterUrlProtocol")
+                {
+                    RequireElevated(string.Join(" ", args));
+                    bool result = UnregisterUriScheme("m3u8dl");
+                    Console.WriteLine(result ? strings.unregisterUrlProtocolSuccessful : strings.unregisterUrlProtocolFailed);
+                    Environment.Exit(0);
+                }
+            }
 
             //寻找ffmpeg.exe
             if (File.Exists("ffmpeg.exe"))
@@ -191,7 +218,7 @@ namespace N_m3u8DL_CLI.NetCore
                 if (o.EnableAudioOnly) Global.VIDEO_TYPE = "IGNORE";
                 if (!string.IsNullOrEmpty(o.WorkDir))
                 {
-                    workDir = o.WorkDir;
+                    workDir = Environment.ExpandEnvironmentVariables(o.WorkDir);
                     DownloadManager.HasSetDir = true;
                 }
 
@@ -412,6 +439,62 @@ namespace N_m3u8DL_CLI.NetCore
             catch (Exception ex)
             {
                 LOGGER.PrintLine(ex.Message, LOGGER.Error);
+            }
+        }
+
+        public static bool RegisterUriScheme(string scheme, string applicationPath)
+        {
+            try
+            {
+                using (var schemeKey = Registry.ClassesRoot.CreateSubKey(scheme, writable: true))
+                {
+                    schemeKey.SetValue("", "URL:m3u8DL Protocol");
+                    schemeKey.SetValue("URL Protocol", "");
+                    using (var defaultIconKey = schemeKey.CreateSubKey("DefaultIcon"))
+                    {
+                        defaultIconKey.SetValue("", $"\"{applicationPath}\",1");
+                    }
+                    using (var shellKey = schemeKey.CreateSubKey("shell"))
+                    using (var openKey = shellKey.CreateSubKey("open"))
+                    using (var commandKey = openKey.CreateSubKey("command"))
+                    {
+                        commandKey.SetValue("", $"\"{applicationPath}\" \"%1\"");
+                        return true;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
+            return false;
+        }
+
+        public static bool UnregisterUriScheme(string scheme)
+        {
+            try
+            {
+                Registry.ClassesRoot.DeleteSubKeyTree(scheme);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
+            return false;
+        }
+
+        public static void RequireElevated(string cmd)
+        {
+            if (!UACHelper.UACHelper.IsElevated)
+            {
+                string[] arguments = Environment.GetCommandLineArgs();
+                UACHelper.UACHelper.StartElevated(
+                    new ProcessStartInfo(Assembly.GetExecutingAssembly().Location, cmd)
+                );
+                Environment.Exit(0);
             }
         }
 

--- a/N_m3u8DL-CLI/packages.config
+++ b/N_m3u8DL-CLI/packages.config
@@ -9,4 +9,6 @@
   <package id="NiL.JS" version="2.5.1428" targetFramework="net46" />
   <package id="Resource.Embedder" version="2.1.1" targetFramework="net46" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net46" />
+  <package id="TaskScheduler" version="2.8.7" targetFramework="net46" />
+  <package id="UACHelper" version="1.3.0.5" targetFramework="net46" />
 </packages>

--- a/N_m3u8DL-CLI/strings.Designer.cs
+++ b/N_m3u8DL-CLI/strings.Designer.cs
@@ -19,7 +19,7 @@ namespace N_m3u8DL_CLI {
     // 类通过类似于 ResGen 或 Visual Studio 的工具自动生成的。
     // 若要添加或移除成员，请编辑 .ResX 文件，然后重新运行 ResGen
     // (以 /str 作为命令选项)，或重新生成 VS 项目。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class strings {
@@ -439,6 +439,15 @@ namespace N_m3u8DL_CLI {
         }
         
         /// <summary>
+        ///   查找类似 注册m3u8dl链接协议 的本地化字符串。
+        /// </summary>
+        public static string Help_registerUrlProtocol {
+            get {
+                return ResourceManager.GetString("Help_registerUrlProtocol", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 设定程序的重试次数 的本地化字符串。
         /// </summary>
         public static string Help_retryCount {
@@ -471,6 +480,15 @@ namespace N_m3u8DL_CLI {
         public static string Help_timeOut {
             get {
                 return ResourceManager.GetString("Help_timeOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 取消注册m3u8dl链接协议 的本地化字符串。
+        /// </summary>
+        public static string Help_unregisterUrlProtocol {
+            get {
+                return ResourceManager.GetString("Help_unregisterUrlProtocol", resourceCulture);
             }
         }
         
@@ -637,6 +655,24 @@ namespace N_m3u8DL_CLI {
         }
         
         /// <summary>
+        ///   查找类似 注册m3u8dl链接协议失败！ 的本地化字符串。
+        /// </summary>
+        public static string registerUrlProtocolFailed {
+            get {
+                return ResourceManager.GetString("registerUrlProtocolFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 注册m3u8dl链接协议成功！ 的本地化字符串。
+        /// </summary>
+        public static string registerUrlProtocolSuccessful {
+            get {
+                return ResourceManager.GetString("registerUrlProtocolSuccessful", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 将文件转换到 MPEG-TS 封装： 的本地化字符串。
         /// </summary>
         public static string remuxToMPEGTS {
@@ -750,6 +786,24 @@ namespace N_m3u8DL_CLI {
         public static string taskDone {
             get {
                 return ResourceManager.GetString("taskDone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 取消注册m3u8dl链接协议失败！ 的本地化字符串。
+        /// </summary>
+        public static string unregisterUrlProtocolFailed {
+            get {
+                return ResourceManager.GetString("unregisterUrlProtocolFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 取消注册m3u8dl链接协议成功！ 的本地化字符串。
+        /// </summary>
+        public static string unregisterUrlProtocolSuccessful {
+            get {
+                return ResourceManager.GetString("unregisterUrlProtocolSuccessful", resourceCulture);
             }
         }
         

--- a/N_m3u8DL-CLI/strings.en-US.resx
+++ b/N_m3u8DL-CLI/strings.en-US.resx
@@ -357,4 +357,22 @@
   <data name="Help_disableIntegrityCheck" xml:space="preserve">
     <value>Disable integrity check</value>
   </data>
+  <data name="Help_registerUrlProtocol" xml:space="preserve">
+    <value>Register m3u8dl URL protocol</value>
+  </data>
+  <data name="Help_unregisterUrlProtocol" xml:space="preserve">
+    <value>Unregister m3u8dl URL protocol</value>
+  </data>
+  <data name="registerUrlProtocolFailed" xml:space="preserve">
+    <value>Register m3u8dl URL protocol failed!</value>
+  </data>
+  <data name="registerUrlProtocolSuccessful" xml:space="preserve">
+    <value>Register m3u8dl URL protocol successfully!</value>
+  </data>
+  <data name="unregisterUrlProtocolFailed" xml:space="preserve">
+    <value>Unregister m3u8dl URL protocol failed!</value>
+  </data>
+  <data name="unregisterUrlProtocolSuccessful" xml:space="preserve">
+    <value>Unregister m3u8dl URL protocol successfully!</value>
+  </data>
 </root>

--- a/N_m3u8DL-CLI/strings.resx
+++ b/N_m3u8DL-CLI/strings.resx
@@ -357,4 +357,22 @@
   <data name="Help_disableIntegrityCheck" xml:space="preserve">
     <value>不检测分片数量是否完整</value>
   </data>
+  <data name="Help_registerUrlProtocol" xml:space="preserve">
+    <value>注册m3u8dl链接协议</value>
+  </data>
+  <data name="Help_unregisterUrlProtocol" xml:space="preserve">
+    <value>取消注册m3u8dl链接协议</value>
+  </data>
+  <data name="registerUrlProtocolFailed" xml:space="preserve">
+    <value>注册m3u8dl链接协议失败！</value>
+  </data>
+  <data name="registerUrlProtocolSuccessful" xml:space="preserve">
+    <value>注册m3u8dl链接协议成功！</value>
+  </data>
+  <data name="unregisterUrlProtocolFailed" xml:space="preserve">
+    <value>取消注册m3u8dl链接协议失败！</value>
+  </data>
+  <data name="unregisterUrlProtocolSuccessful" xml:space="preserve">
+    <value>取消注册m3u8dl链接协议成功！</value>
+  </data>
 </root>

--- a/N_m3u8DL-CLI/strings.zh-TW.resx
+++ b/N_m3u8DL-CLI/strings.zh-TW.resx
@@ -357,4 +357,22 @@
   <data name="Help_disableIntegrityCheck" xml:space="preserve">
     <value>不檢測分片數量是否完整</value>
   </data>
+  <data name="Help_registerUrlProtocol" xml:space="preserve">
+    <value>注册m3u8dl連結協定</value>
+  </data>
+  <data name="Help_unregisterUrlProtocol" xml:space="preserve">
+    <value>取消注册m3u8dl連結協定</value>
+  </data>
+  <data name="registerUrlProtocolFailed" xml:space="preserve">
+    <value>注册m3u8dl連結協定失敗！</value>
+  </data>
+  <data name="registerUrlProtocolSuccessful" xml:space="preserve">
+    <value>注册m3u8dl連結協定成功！</value>
+  </data>
+  <data name="unregisterUrlProtocolFailed" xml:space="preserve">
+    <value>取消注册m3u8dl連結協定失敗！</value>
+  </data>
+  <data name="unregisterUrlProtocolSuccessful" xml:space="preserve">
+    <value>取消注册m3u8dl連結協定成功！</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
   * 支持仅合并为音频
   * 支持设置特定http代理
   * 支持自动使用系统代理（默认行为, 可禁止）
+  * 支持m3u8dl链接协议（通过web链接调用本机客户端）
   * 提供SimpleG简易的`GUI`生成常用参数
 
 
@@ -81,6 +82,8 @@ N_m3u8DL-CLI.exe <URL|File|JSON> [OPTIONS]
     --noMerge                   禁用自动合并
     --noProxy                   不自动使用系统代理
     --disableIntegrityCheck     不检测分片数量是否完整
+    --registerUrlProtocol       注册m3u8dl链接协议
+    --unregisterUrlProtocol     取消注册m3u8dl链接协议
 ```
 
 # 用户文档


### PR DESCRIPTION
目的：通过web链接调用本机客户端。
主要改动：
1.  添加m3u8dl链接解析功能。
2.  添加注册和取消注册本机m3u8dl链接协议的功能和命令行参数。
3.  添加申请UAC管理员权限的功能，注册本机链接协议需要管理员权限（用到了UACHelper库）。
4.  添加了WorkDir参数对系统环境变量的支持，方便web程序定位下载目录，比如：%USERPROFILE%\Downloads。
5.  添加相关功能的国际化文本。

URI格式：
`m3u8dl:<base64编码的客户端命令行文本>`
URI示例：`m3u8dl:Imh0dHBzOi8vZXhhbXBsZS5jb20vYWJjLm0zdTgiIC0td29ya0RpciAiJVVTRVJQUk9GSUxFJVxEb3dubG9hZHNcbTN1OGRsIiAtLXNhdmVOYW1lICJhYmMiIC0tZW5hYmxlRGVsQWZ0ZXJEb25lIC0tZGlzYWJsZURhdGVJbmZvIC0tbm9Qcm94eQ==`
URI解码：
`m3u8dl:"https://example.com/abc.m3u8" --workDir "%USERPROFILE%\Downloads\m3u8dl" --saveName "abc" --enableDelAfterDone --disableDateInfo --noProxy`

参考：
- [Registering an Application to a URI Scheme](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa767914(v=vs.85)?redirectedfrom=MSDN)