### PR TITLE
fix: 修正m3u8dl协议 转义符问题

### DIFF
--- a/N_m3u8DL-CLI/Program.cs
+++ b/N_m3u8DL-CLI/Program.cs
@@ -81,6 +81,8 @@ namespace N_m3u8DL_CLI.NetCore
                     var cmd = "";
                     try { cmd = Encoding.UTF8.GetString(Convert.FromBase64String(base64)); }
                     catch (FormatException) { cmd = Encoding.UTF8.GetString(Convert.FromBase64String(base64.TrimEnd('/'))); }
+                    //修正参数转义符
+                    cmd = cmd.Replace("\\\"", "\"");
                     //修正工作目录
                     Environment.CurrentDirectory = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
                     args = Global.ParseArguments(cmd).ToArray();  //解析命令行


### PR DESCRIPTION
`m3u8dl://` 协议 --workDir 参数 末尾是斜杠 `--workDir "D:\Downloads\"` 导致无法正常解析程序闪退。

例如参数:
`"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8" --workDir "%USERPROFILE%\Downloads\m3u8dl\"`
处理成m3u8dl协议
`m3u8dl://Imh0dHBzOi8vYml0ZGFzaC1hLmFrYW1haWhkLm5ldC9jb250ZW50L3NpbnRlbC9obHMvcGxheWxpc3QubTN1OCIgLS13b3JrRGlyICIlVVNFUlBST0ZJTEUlXERvd25sb2Fkc1xtM3U4ZGxcIg==`
无法正常工作