### PR TITLE
阻止Accept-Encoding字段重复设置

### DIFF
--- a/N_m3u8DL-CLI/Global.cs
+++ b/N_m3u8DL-CLI/Global.cs
@@ -185,7 +185,7 @@ namespace N_m3u8DL_CLI
                                     webRequest.AddRange(Convert.ToInt32(att.Substring(att.IndexOf(":") + 1).Split('-')[0], Convert.ToInt32(att.Substring(att.IndexOf(":") + 1).Split('-')[1])));
                                 else if (att.Split(':')[0].ToLower() == "accept")
                                     webRequest.Accept = att.Substring(att.IndexOf(":") + 1);
-                                else
+                                else if(att.Split(':')[0].ToLower() != "accept-encoding")
                                     webRequest.Headers.Add(att);
                             }
                             catch (Exception e)


### PR DESCRIPTION
实践中发现存在该字段重复设置的可能。该字段在L162赋初值，在L189可能重复。表现为：
<img src = 'https://i.bmp.ovh/imgs/2022/07/14/58b2684bc8ad8459.png' />

(testing case)[https://prd-vcache.edge-global.akamai.tvb.com/v11/newsbksdrm/_definst_/smil:news/inews1/20220713/archive_26_697473_1280_720_1500k_cht_proenv_can.smil/manifest.mpd?hdnea=ip=0.0.0.0~st=1657739530~exp=1657825930~acl=/v11/newsbksdrm/_definst_/smil:news/inews1/20220713/archive_26_697473_1280_720_1500k_cht_proenv_can.smil/*~hmac=5439856aadc2f65865ea69c649e10c20db948239ad94ed5b2696578f6aa9d15d]