### PR TITLE
修复 录制间隔负数导致错误

### DIFF
--- a/N_m3u8DL-CLI/HLSLiveDownloader.cs
+++ b/N_m3u8DL-CLI/HLSLiveDownloader.cs
@@ -61,7 +61,7 @@ namespace N_m3u8DL_CLI
             string m3u8Url = initJson["m3u8"].Value<string>();
             targetduration = initJson["m3u8Info"]["targetDuration"].Value<double>();
             TotalDuration = initJson["m3u8Info"]["totalDuration"].Value<double>();
-            timer.Interval = (TotalDuration - targetduration) * 1000;//设置定时器运行间隔
+            timer.Interval = Math.Abs(TotalDuration - targetduration) * 1000;//设置定时器运行间隔
             if (timer.Interval <= 1000) timer.Interval = 10000;
             JArray lastSegments = JArray.Parse(initJson["m3u8Info"]["segments"][0].ToString().Trim());  //上次的分段，用于比对新分段
             ArrayList tempList = new ArrayList();  //所有待下载的列表


### PR DESCRIPTION
一些奇怪的网站 比如 chaturbate 直播m3u8
TotalDuration会比targetduration小导致timer.Interval是负数抛出错误，无法录制直播。